### PR TITLE
fix: security, bugs, and code quality improvements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,14 +8,13 @@ jobs:
 
     strategy:
       matrix:
-        # the Node.js versions to build on
-        node-version: [14.x, 15.x, 16.x, 17.x, 18.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - name: Use Node.js ${{ matrix.node-version }} 
-        uses: actions/setup-node@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jkoehl/homebridge-waterguru",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jkoehl/homebridge-waterguru",
-      "version": "0.2.0",
+      "version": "0.2.1",
       "license": "Apache-2.0",
       "dependencies": {
         "aws-amplify": "^5.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,7 @@
       "version": "0.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "async-debounce-promise": "^0.0.2",
-        "aws-amplify": "^5.0",
-        "crypto": "^1.0.1",
-        "uuid": "^9.0.0"
+        "aws-amplify": "^5.0"
       },
       "devDependencies": {
         "@types/node": "^18.0",
@@ -9955,11 +9952,6 @@
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
       "peer": true
     },
-    "node_modules/async-debounce-promise": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/async-debounce-promise/-/async-debounce-promise-0.0.2.tgz",
-      "integrity": "sha512-AwwgZYnoJXtE+2HSMS0ObRw3hqs5d/Y+ipHNpN6wNTFmQGWH6AqfbGtb5fX5tYY4GgS7Q1Y2rcBmC7EUoo3hWA=="
-    },
     "node_modules/async-limiter": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.1.tgz",
@@ -10933,12 +10925,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/crypto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
-      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
-      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in."
     },
     "node_modules/dayjs": {
       "version": "1.11.7",
@@ -17720,14 +17706,6 @@
       "peer": true,
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "main": "dist/index.js",
   "scripts": {
-    "lint": "eslint src/**.ts --max-warnings=0",
+    "lint": "eslint \"src/**/*.ts\" --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
     "testWg": "node ./dist/wgTest/index.js",
@@ -27,10 +27,7 @@
     "homebridge-plugin"
   ],
   "dependencies": {
-    "async-debounce-promise": "^0.0.2",
-    "aws-amplify": "^5.0",
-    "crypto": "^1.0.1",
-    "uuid": "^9.0.0"
+    "aws-amplify": "^5.0"
   },
   "devDependencies": {
     "@types/node": "^18.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Waterguru",
   "name": "@jkoehl/homebridge-waterguru",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Reads water testing results from a Waterguru device",
   "license": "Apache-2.0",
   "repository": {

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -1,17 +1,16 @@
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { v4 as uuidv4 } from 'uuid';
 
 import { WaterguruPlatform } from './platform';
 
-// Custom UUIDs for services and characteristics
+// Fixed UUIDs — must never change or HomeKit will create orphaned services on every restart
 const CustomServiceUUID = {
-  PhService: uuidv4(),
-  ChlorineService: uuidv4(),
+  PhService: 'A0000001-079E-48FF-8F27-9C2605A29F52',
+  ChlorineService: 'A0000002-079E-48FF-8F27-9C2605A29F52',
 };
 
 const CustomCharacteristicUUID = {
-  CurrentPh: uuidv4(),
-  CurrentChlorine: uuidv4(),
+  CurrentPh: 'B863F10C-079E-48FF-8F27-9C2605A29F52',
+  CurrentChlorine: 'B863F10D-079E-48FF-8F27-9C2605A29F52',
 };
 
 export class WaterguruPlatformAccessory {
@@ -47,7 +46,7 @@ export class WaterguruPlatformAccessory {
       minValue: 0,
       maxValue: 14,
       minStep: 0.1,
-      perms: [this.platform.Characteristic.Perms.READ, this.platform.Characteristic.Perms.NOTIFY],
+      perms: [this.platform.Characteristic.Perms.PAIRED_READ, this.platform.Characteristic.Perms.NOTIFY],
     });
     this.phService.addCharacteristic(CurrentPh);
     CurrentPh.onGet(this.getCurrentPh.bind(this));
@@ -62,54 +61,60 @@ export class WaterguruPlatformAccessory {
       minValue: 0,
       maxValue: 10,
       minStep: 0.1,
-      perms: [this.platform.Characteristic.Perms.READ, this.platform.Characteristic.Perms.NOTIFY],
+      perms: [this.platform.Characteristic.Perms.PAIRED_READ, this.platform.Characteristic.Perms.NOTIFY],
     });
     this.chlorineService.addCharacteristic(CurrentChlorine);
     CurrentChlorine.onGet(this.getCurrentFreeChlorine.bind(this));
   }
 
-  /**
-   * Handle "SET" requests from HomeKit
-   * These are sent when the user changes the state of an accessory, for example, turning on a Light bulb.
-   */
-  // async setOn(value: CharacteristicValue) {
-  //   // implement your own code to turn your device on/off
-  //   this.exampleStates.On = value as boolean;
-
-  //   this.platform.log.debug('Set Characteristic On ->', value);
-  // }
-
-
-
   async getCurrentTemp(): Promise<CharacteristicValue> {
-    const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
-    this.accessory.context.device = waterBody;
-    return (5/9) * (this.accessory.context.device.waterTemp - 32);
+    try {
+      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
+      if (!waterBody) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      this.accessory.context.device = waterBody;
+      return (5 / 9) * (this.accessory.context.device.waterTemp - 32);
+    } catch (error) {
+      this.platform.log.error('Failed to get temperature:', error);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
   }
 
   async getCurrentFreeChlorine(): Promise<CharacteristicValue> {
-    const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
-    this.accessory.context.device = waterBody;
-    const measurement = this.accessory.context.device.measurements.find((measurement) => (measurement.type === 'FREE_CL'));
-    return parseFloat(measurement.value);
+    try {
+      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
+      if (!waterBody) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      this.accessory.context.device = waterBody;
+      const measurement = this.accessory.context.device.measurements.find((m) => m.type === 'FREE_CL');
+      if (!measurement) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      return parseFloat(measurement.value);
+    } catch (error) {
+      this.platform.log.error('Failed to get free chlorine:', error);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
   }
 
   async getCurrentPh(): Promise<CharacteristicValue> {
-    const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
-    this.accessory.context.device = waterBody;
-    const measurement = this.accessory.context.device.measurements.find((measurement) => (measurement.type === 'PH'));
-    return parseFloat(measurement.value);
+    try {
+      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
+      if (!waterBody) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      this.accessory.context.device = waterBody;
+      const measurement = this.accessory.context.device.measurements.find((m) => m.type === 'PH');
+      if (!measurement) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      return parseFloat(measurement.value);
+    } catch (error) {
+      this.platform.log.error('Failed to get pH:', error);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
   }
-
-  /**
-   * Handle "SET" requests from HomeKit
-   * These are sent when the user changes the state of an accessory, for example, changing the Brightness
-   */
-  // async setBrightness(value: CharacteristicValue) {
-  //   // implement your own code to set the brightness
-  //   this.exampleStates.Brightness = value as number;
-
-  //   this.platform.log.debug('Set Characteristic Brightness -> ', value);
-  // }
 
 }

--- a/src/services/cognito.service.ts
+++ b/src/services/cognito.service.ts
@@ -20,8 +20,9 @@ export default class Cognito {
     });
   }
 
-  public async signInUser(username: string, password: string): Promise<CognitoUser | any> {
-    this.cognitoUser = await Auth.signIn(username, password);
-    return this.cognitoUser;
+  public async signInUser(username: string, password: string): Promise<CognitoUser> {
+    const user: CognitoUser = await Auth.signIn(username, password);
+    this.cognitoUser = user;
+    return user;
   }
 }

--- a/src/services/wg.service.ts
+++ b/src/services/wg.service.ts
@@ -1,6 +1,7 @@
 import Cognito from './cognito.service';
 import { Amplify, API } from 'aws-amplify';
 import { Logger } from 'homebridge';
+import { CognitoUser } from '@aws-amplify/auth';
 
 export default class WaterguruService {
 
@@ -27,11 +28,12 @@ export default class WaterguruService {
     });
   }
 
-  public async signInUser(username: string, password: string): Promise<any> {
+  public async signInUser(username: string, password: string): Promise<CognitoUser> {
     return this.cognitoSvc.signInUser(username, password);
   }
 
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async getDashboardInfo(): Promise<any> {
     const apiName = 'WGLambda';
     const path = '/';
@@ -51,6 +53,7 @@ export default class WaterguruService {
     return this.cachedDashboardInfo;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   public async getWaterbodyInfo(waterBodyId: string): Promise<any> {
     const dashboardInfo = await this.getDashboardInfo();
     return dashboardInfo.waterBodies.find((curWaterBody) => (curWaterBody.waterBodyId === waterBodyId));

--- a/src/services/wg.service.ts
+++ b/src/services/wg.service.ts
@@ -5,7 +5,7 @@ import { Logger } from 'homebridge';
 export default class WaterguruService {
 
 
-  public cognitoSvc: Cognito;
+  private cognitoSvc: Cognito;
   private cachedDashboardInfo = null;
   private lastDashboardCallTime = 0;
 
@@ -44,7 +44,7 @@ export default class WaterguruService {
     if (curTimeMS - 60000 > this.lastDashboardCallTime) {
       this.lastDashboardCallTime = curTimeMS;
       this.log.debug('Refreshing dashboard info from cloud');
-      this.cachedDashboardInfo = await API.post(apiName, path, myInit), 0;
+      this.cachedDashboardInfo = await API.post(apiName, path, myInit);
     } else {
       this.log.debug('Returning cached dashboard info last check:', new Date(this.lastDashboardCallTime));
     }

--- a/src/wgTest/index.ts
+++ b/src/wgTest/index.ts
@@ -1,7 +1,16 @@
 import WaterguruService from '../services/wg.service';
 
+const username = process.env.WG_USERNAME || process.argv[2];
+const password = process.env.WG_PASSWORD || process.argv[3];
+
+if (!username || !password) {
+  console.error('Usage: WG_USERNAME=<email> WG_PASSWORD=<pass> npm run testWg');
+  console.error('   or: npm run testWg -- <email> <password>');
+  process.exit(1);
+}
+
 const wgService = new WaterguruService(console);
-const userInfoPromise = wgService.signInUser('jkoehl@gmail.com', 'GFKW4CoMM-wadq6W');
+const userInfoPromise = wgService.signInUser(username, password);
 userInfoPromise.then((userInfo) => {
   console.log(userInfo);
 }).then(() => {

--- a/src/wgTest/index.ts
+++ b/src/wgTest/index.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import WaterguruService from '../services/wg.service';
 
 const username = process.env.WG_USERNAME || process.argv[2];


### PR DESCRIPTION
- Security: remove hardcoded credentials from wgTest/index.ts; now reads
  from WG_USERNAME/WG_PASSWORD env vars or CLI args
- Bug: replace random uuidv4() UUIDs in platformAccessory.ts with fixed
  UUIDs so HomeKit doesn't accumulate orphaned services on every restart
- Bug: fix comma-operator typo on API.post assignment in wg.service.ts
- Bug: add try/catch + HapStatusError to all characteristic getters so
  HomeKit shows "No Response" on API failures instead of crashing
- Refactor: make cognitoSvc private in WaterguruService (was unintentionally public)
- Deps: remove unused async-debounce-promise, deprecated crypto npm shim,
  and uuid (no longer needed after UUID fix)
- DX: fix eslint glob pattern (src/**.ts → "src/**/*.ts") to cover subdirs
- CI: update actions/checkout and actions/setup-node from v2 to v4;
  drop EOL Node versions (14,15,16,17); add Node 20 and 22

https://claude.ai/code/session_01MKaFEXDaGm9XYBthBDvBxb