### PR TITLE
Device Types as Light Sensors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Waterguru",
   "name": "homebridge-waterguru-plus",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Reads water testing results from a Waterguru device",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Waterguru",
   "name": "homebridge-waterguru-plus",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Reads water testing results from a Waterguru device",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Waterguru",
   "name": "homebridge-waterguru-noDevKev",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Reads water testing results from a Waterguru device",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Waterguru",
   "name": "homebridge-waterguru-plus",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Reads water testing results from a Waterguru device",
   "license": "Apache-2.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "displayName": "Homebridge Waterguru",
-  "name": "@jkoehl/homebridge-waterguru",
+  "name": "homebridge-waterguru-gibbs",
   "version": "0.2.1",
   "description": "Reads water testing results from a Waterguru device",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/jkoehl/homebridge-waterguru.git"
+    "url": "git://github.com/YOUR_GITHUB_USERNAME/homebridge-waterguru.git"
   },
   "bugs": {
-    "url": "https://github.com/jkoehl/homebridge-waterguru/issues"
+    "url": "https://github.com/YOUR_GITHUB_USERNAME/homebridge-waterguru/issues"
   },
   "engines": {
     "node": ">=14.18.1",
@@ -20,6 +20,7 @@
     "lint": "eslint \"src/**/*.ts\" --max-warnings=0",
     "watch": "npm run build && npm link && nodemon",
     "build": "rimraf ./dist && tsc",
+    "prepare": "npm run build",
     "testWg": "node ./dist/wgTest/index.js",
     "prepublishOnly": "npm run lint && npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
   "displayName": "Homebridge Waterguru",
-  "name": "homebridge-waterguru-gibbs",
+  "name": "homebridge-waterguru-noDevKev",
   "version": "0.2.1",
   "description": "Reads water testing results from a Waterguru device",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/YOUR_GITHUB_USERNAME/homebridge-waterguru.git"
+    "url": "git://github.com/noDevKev/homebridge-waterguru.git"
   },
   "bugs": {
-    "url": "https://github.com/YOUR_GITHUB_USERNAME/homebridge-waterguru/issues"
+    "url": "https://github.com/noDevKev/homebridge-waterguru/issues"
   },
   "engines": {
     "node": ">=14.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "displayName": "Homebridge Waterguru",
-  "name": "homebridge-waterguru-noDevKev",
+  "name": "homebridge-waterguru-plus",
   "version": "0.2.2",
   "description": "Reads water testing results from a Waterguru device",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Waterguru",
   "name": "homebridge-waterguru-plus",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Reads water testing results from a Waterguru device",
   "license": "Apache-2.0",
   "repository": {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,76 +1,99 @@
-import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, Service, Characteristic } from 'homebridge';
+import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 
-import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
-import { WaterguruPlatformAccessory } from './platformAccessory';
+import { WaterguruPlatform } from './platform';
 
-import WaterguruService from './services/wg.service';
-import {CustomWGCharacteristic} from './CustomWGCharacteristic';
-
-export class WaterguruPlatform implements DynamicPlatformPlugin {
-  public readonly Service: typeof Service = this.api.hap.Service;
-  public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
-
-  public readonly accessories: PlatformAccessory[] = [];
-
-  public waterguruSvc: WaterguruService | undefined;
-  public customCharacteristic: CustomWGCharacteristic;
+export class WaterguruPlatformAccessory {
+  private temperatureService: Service;
+  private phService: Service;
+  private chlorineService: Service;
 
   constructor(
-    public readonly log: Logger,
-    public readonly config: PlatformConfig,
-    public readonly api: API,
+    private readonly platform: WaterguruPlatform,
+    private readonly accessory: PlatformAccessory,
   ) {
-    this.log.debug('Finished initializing platform:', this.config.name);
-    this.customCharacteristic = new CustomWGCharacteristic(api);
 
-    this.api.on('didFinishLaunching', () => {
-      log.debug('Executed didFinishLaunching callback');
-      this.waterguruSvc = new WaterguruService(this.log);
-      this.waterguruSvc?.signInUser(config['wg-username'], config['wg-password'])
-        .then( () => {
-          this.discoverDevices();
-        });
-    });
+    // Set accessory information
+    this.accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'WaterGuru')
+      .setCharacteristic(this.platform.Characteristic.Model, 'Unknown')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, 'Unknown');
+
+    // Temperature Service (standard HomeKit — works as-is)
+    this.temperatureService = this.accessory.getService(this.platform.Service.TemperatureSensor) ||
+      this.accessory.addService(this.platform.Service.TemperatureSensor);
+    this.temperatureService.setCharacteristic(this.platform.Characteristic.Name, 'Temperature');
+    this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+      .onGet(this.getCurrentTemp.bind(this));
+
+    // pH Service — exposed as HumiditySensor (native HomeKit type Apple Home will display)
+    // pH 0–14 is scaled to 0–100 for the humidity characteristic (multiply by 100/14 ≈ 7.14)
+    // Example: pH 7.4 → displayed as ~52.9 "humidity" — label the tile "pH" in the Home app
+    this.phService = this.accessory.getService('pH') ||
+      this.accessory.addService(this.platform.Service.HumiditySensor, 'pH', 'waterguru-ph');
+    this.phService.setCharacteristic(this.platform.Characteristic.Name, 'pH');
+    this.phService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+      .onGet(this.getCurrentPh.bind(this));
+
+    // Chlorine Service — also exposed as HumiditySensor with a unique subtype
+    // Free chlorine 0–10 ppm is scaled to 0–100 (multiply by 10)
+    // Example: 2.5 ppm → displayed as 25 "humidity" — label the tile "Chlorine" in the Home app
+    this.chlorineService = this.accessory.getService('Chlorine') ||
+      this.accessory.addService(this.platform.Service.HumiditySensor, 'Chlorine', 'waterguru-chlorine');
+    this.chlorineService.setCharacteristic(this.platform.Characteristic.Name, 'Chlorine');
+    this.chlorineService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+      .onGet(this.getCurrentFreeChlorine.bind(this));
   }
 
-  /**
-   * This function is invoked when homebridge restores cached accessories from disk at startup.
-   * It should be used to setup event handlers for characteristics and update respective values.
-   */
-  configureAccessory(accessory: PlatformAccessory) {
-    this.log.info('Loading accessory from cache:', accessory.displayName);
-    this.accessories.push(accessory);
+  async getCurrentTemp(): Promise<CharacteristicValue> {
+    try {
+      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
+      if (!waterBody) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      this.accessory.context.device = waterBody;
+      return (5 / 9) * (this.accessory.context.device.waterTemp - 32);
+    } catch (error) {
+      this.platform.log.error('Failed to get temperature:', error);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
   }
 
-  discoverDevices() {
-
-    this.waterguruSvc && this.waterguruSvc.getDashboardInfo()
-      .then( (dashboardInfo => {
-        this.log.debug(dashboardInfo);
-
-        // Remove any cached devices that we did not get from the WG service
-        const accsNoLongerPresent = this.accessories.filter((o1) => !dashboardInfo.waterBodies.some((o2) => o1.UUID === o2.waterBodyId));
-        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, accsNoLongerPresent);
-
-        for (const waterBody of dashboardInfo.waterBodies) {
-
-          const existingAccessory = this.accessories.find(accessory => accessory.UUID === waterBody.waterBodyId);
-          if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.device = waterBody;
-            this.api.updatePlatformAccessories([existingAccessory]);
-            new WaterguruPlatformAccessory(this, existingAccessory);
-          } else {
-            // the accessory does not yet exist, so we need to create it
-            this.log.info('Adding new accessory:', waterBody.name);
-            const accessory = new this.api.platformAccessory(waterBody.name, waterBody.waterBodyId);
-            accessory.context.device = waterBody;
-            new WaterguruPlatformAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
-          }
-        }
-      }));
+  async getCurrentFreeChlorine(): Promise<CharacteristicValue> {
+    try {
+      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
+      if (!waterBody) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      this.accessory.context.device = waterBody;
+      const measurement = this.accessory.context.device.measurements.find((m) => m.type === 'FREE_CL');
+      if (!measurement) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      // Scale 0–10 ppm → 0–100 for HomeKit humidity characteristic
+      return Math.min(100, Math.max(0, parseFloat(measurement.value) * 10));
+    } catch (error) {
+      this.platform.log.error('Failed to get free chlorine:', error);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
   }
+
+  async getCurrentPh(): Promise<CharacteristicValue> {
+    try {
+      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
+      if (!waterBody) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      this.accessory.context.device = waterBody;
+      const measurement = this.accessory.context.device.measurements.find((m) => m.type === 'PH');
+      if (!measurement) {
+        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+      }
+      // Scale 0–14 pH → 0–100 for HomeKit humidity characteristic
+      return Math.min(100, Math.max(0, parseFloat(measurement.value) * (100 / 14)));
+    } catch (error) {
+      this.platform.log.error('Failed to get pH:', error);
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+  }
+
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2,17 +2,23 @@ import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, 
 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
 import { WaterguruPlatformAccessory } from './platformAccessory';
-
 import WaterguruService from './services/wg.service';
-import {CustomWGCharacteristic} from './CustomWGCharacteristic';
+import { CustomWGCharacteristic } from './CustomWGCharacteristic';
+
+// Each measurement becomes its own HomeKit accessory so they appear as
+// separate room tiles instead of being grouped under one accessory.
+const MEASUREMENTS = [
+  { key: 'temp', label: 'Pool Temperature' },
+  { key: 'ph', label: 'Pool pH' },
+  { key: 'chlorine', label: 'Pool Chlorine' },
+];
 
 export class WaterguruPlatform implements DynamicPlatformPlugin {
   public readonly Service: typeof Service = this.api.hap.Service;
   public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
 
   public readonly accessories: PlatformAccessory[] = [];
-
-  public waterguruSvc: WaterguruService | undefined;
+  public waterguruSvc?: WaterguruService;
   public customCharacteristic: CustomWGCharacteristic;
 
   constructor(
@@ -26,51 +32,58 @@ export class WaterguruPlatform implements DynamicPlatformPlugin {
     this.api.on('didFinishLaunching', () => {
       log.debug('Executed didFinishLaunching callback');
       this.waterguruSvc = new WaterguruService(this.log);
-      this.waterguruSvc?.signInUser(config['wg-username'], config['wg-password'])
-        .then( () => {
-          this.discoverDevices();
-        });
+      this.waterguruSvc?.signInUser(config['wg-username'], config['wg-password']).then(() => {
+        this.discoverDevices();
+      });
     });
   }
 
-  /**
-   * This function is invoked when homebridge restores cached accessories from disk at startup.
-   * It should be used to setup event handlers for characteristics and update respective values.
-   */
   configureAccessory(accessory: PlatformAccessory) {
     this.log.info('Loading accessory from cache:', accessory.displayName);
     this.accessories.push(accessory);
   }
 
   discoverDevices() {
-
     this.waterguruSvc && this.waterguruSvc.getDashboardInfo()
-      .then( (dashboardInfo => {
+      .then((dashboardInfo) => {
         this.log.debug(dashboardInfo);
 
-        // Remove any cached devices that we did not get from the WG service
-        const accsNoLongerPresent = this.accessories.filter((o1) => !dashboardInfo.waterBodies.some((o2) => o1.UUID === o2.waterBodyId));
-        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, accsNoLongerPresent);
-
+        // Build the set of UUIDs we expect (one per measurement per water body)
+        const expectedUUIDs: string[] = [];
         for (const waterBody of dashboardInfo.waterBodies) {
-
-          const existingAccessory = this.accessories.find(accessory => accessory.UUID === waterBody.waterBodyId);
-          if (existingAccessory) {
-            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
-
-            existingAccessory.context.device = waterBody;
-            this.api.updatePlatformAccessories([existingAccessory]);
-            new WaterguruPlatformAccessory(this, existingAccessory);
-          } else {
-            // the accessory does not yet exist, so we need to create it
-            this.log.info('Adding new accessory:', waterBody.name);
-            const accessory = new this.api.platformAccessory(waterBody.name, waterBody.waterBodyId);
-            accessory.context.device = waterBody;
-            new WaterguruPlatformAccessory(this, accessory);
-
-            this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+          for (const m of MEASUREMENTS) {
+            expectedUUIDs.push(this.api.hap.uuid.generate(waterBody.waterBodyId + '-' + m.key));
           }
         }
-      }));
+
+        // Remove any cached accessories we no longer expect
+        const accsNoLongerPresent = this.accessories.filter((acc) => !expectedUUIDs.includes(acc.UUID));
+        if (accsNoLongerPresent.length > 0) {
+          this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, accsNoLongerPresent);
+        }
+
+        for (const waterBody of dashboardInfo.waterBodies) {
+          for (const m of MEASUREMENTS) {
+            const uuid = this.api.hap.uuid.generate(waterBody.waterBodyId + '-' + m.key);
+            const displayName = m.label;
+            const existingAccessory = this.accessories.find(acc => acc.UUID === uuid);
+
+            if (existingAccessory) {
+              this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
+              existingAccessory.context.device = waterBody;
+              existingAccessory.context.measurementKey = m.key;
+              this.api.updatePlatformAccessories([existingAccessory]);
+              new WaterguruPlatformAccessory(this, existingAccessory);
+            } else {
+              this.log.info('Adding new accessory:', displayName);
+              const accessory = new this.api.platformAccessory(displayName, uuid);
+              accessory.context.device = waterBody;
+              accessory.context.measurementKey = m.key;
+              new WaterguruPlatformAccessory(this, accessory);
+              this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+            }
+          }
+        }
+      });
   }
 }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1,99 +1,76 @@
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
+import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, Service, Characteristic } from 'homebridge';
 
-import { WaterguruPlatform } from './platform';
+import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
+import { WaterguruPlatformAccessory } from './platformAccessory';
 
-export class WaterguruPlatformAccessory {
-  private temperatureService: Service;
-  private phService: Service;
-  private chlorineService: Service;
+import WaterguruService from './services/wg.service';
+import {CustomWGCharacteristic} from './CustomWGCharacteristic';
+
+export class WaterguruPlatform implements DynamicPlatformPlugin {
+  public readonly Service: typeof Service = this.api.hap.Service;
+  public readonly Characteristic: typeof Characteristic = this.api.hap.Characteristic;
+
+  public readonly accessories: PlatformAccessory[] = [];
+
+  public waterguruSvc: WaterguruService | undefined;
+  public customCharacteristic: CustomWGCharacteristic;
 
   constructor(
-    private readonly platform: WaterguruPlatform,
-    private readonly accessory: PlatformAccessory,
+    public readonly log: Logger,
+    public readonly config: PlatformConfig,
+    public readonly api: API,
   ) {
+    this.log.debug('Finished initializing platform:', this.config.name);
+    this.customCharacteristic = new CustomWGCharacteristic(api);
 
-    // Set accessory information
-    this.accessory.getService(this.platform.Service.AccessoryInformation)!
-      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'WaterGuru')
-      .setCharacteristic(this.platform.Characteristic.Model, 'Unknown')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, 'Unknown');
-
-    // Temperature Service (standard HomeKit — works as-is)
-    this.temperatureService = this.accessory.getService(this.platform.Service.TemperatureSensor) ||
-      this.accessory.addService(this.platform.Service.TemperatureSensor);
-    this.temperatureService.setCharacteristic(this.platform.Characteristic.Name, 'Temperature');
-    this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
-      .onGet(this.getCurrentTemp.bind(this));
-
-    // pH Service — exposed as HumiditySensor (native HomeKit type Apple Home will display)
-    // pH 0–14 is scaled to 0–100 for the humidity characteristic (multiply by 100/14 ≈ 7.14)
-    // Example: pH 7.4 → displayed as ~52.9 "humidity" — label the tile "pH" in the Home app
-    this.phService = this.accessory.getService('pH') ||
-      this.accessory.addService(this.platform.Service.HumiditySensor, 'pH', 'waterguru-ph');
-    this.phService.setCharacteristic(this.platform.Characteristic.Name, 'pH');
-    this.phService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
-      .onGet(this.getCurrentPh.bind(this));
-
-    // Chlorine Service — also exposed as HumiditySensor with a unique subtype
-    // Free chlorine 0–10 ppm is scaled to 0–100 (multiply by 10)
-    // Example: 2.5 ppm → displayed as 25 "humidity" — label the tile "Chlorine" in the Home app
-    this.chlorineService = this.accessory.getService('Chlorine') ||
-      this.accessory.addService(this.platform.Service.HumiditySensor, 'Chlorine', 'waterguru-chlorine');
-    this.chlorineService.setCharacteristic(this.platform.Characteristic.Name, 'Chlorine');
-    this.chlorineService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
-      .onGet(this.getCurrentFreeChlorine.bind(this));
+    this.api.on('didFinishLaunching', () => {
+      log.debug('Executed didFinishLaunching callback');
+      this.waterguruSvc = new WaterguruService(this.log);
+      this.waterguruSvc?.signInUser(config['wg-username'], config['wg-password'])
+        .then( () => {
+          this.discoverDevices();
+        });
+    });
   }
 
-  async getCurrentTemp(): Promise<CharacteristicValue> {
-    try {
-      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
-      if (!waterBody) {
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-      }
-      this.accessory.context.device = waterBody;
-      return (5 / 9) * (this.accessory.context.device.waterTemp - 32);
-    } catch (error) {
-      this.platform.log.error('Failed to get temperature:', error);
-      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-    }
+  /**
+   * This function is invoked when homebridge restores cached accessories from disk at startup.
+   * It should be used to setup event handlers for characteristics and update respective values.
+   */
+  configureAccessory(accessory: PlatformAccessory) {
+    this.log.info('Loading accessory from cache:', accessory.displayName);
+    this.accessories.push(accessory);
   }
 
-  async getCurrentFreeChlorine(): Promise<CharacteristicValue> {
-    try {
-      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
-      if (!waterBody) {
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-      }
-      this.accessory.context.device = waterBody;
-      const measurement = this.accessory.context.device.measurements.find((m) => m.type === 'FREE_CL');
-      if (!measurement) {
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-      }
-      // Scale 0–10 ppm → 0–100 for HomeKit humidity characteristic
-      return Math.min(100, Math.max(0, parseFloat(measurement.value) * 10));
-    } catch (error) {
-      this.platform.log.error('Failed to get free chlorine:', error);
-      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-    }
-  }
+  discoverDevices() {
 
-  async getCurrentPh(): Promise<CharacteristicValue> {
-    try {
-      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
-      if (!waterBody) {
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-      }
-      this.accessory.context.device = waterBody;
-      const measurement = this.accessory.context.device.measurements.find((m) => m.type === 'PH');
-      if (!measurement) {
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-      }
-      // Scale 0–14 pH → 0–100 for HomeKit humidity characteristic
-      return Math.min(100, Math.max(0, parseFloat(measurement.value) * (100 / 14)));
-    } catch (error) {
-      this.platform.log.error('Failed to get pH:', error);
-      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-    }
-  }
+    this.waterguruSvc && this.waterguruSvc.getDashboardInfo()
+      .then( (dashboardInfo => {
+        this.log.debug(dashboardInfo);
 
+        // Remove any cached devices that we did not get from the WG service
+        const accsNoLongerPresent = this.accessories.filter((o1) => !dashboardInfo.waterBodies.some((o2) => o1.UUID === o2.waterBodyId));
+        this.api.unregisterPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, accsNoLongerPresent);
+
+        for (const waterBody of dashboardInfo.waterBodies) {
+
+          const existingAccessory = this.accessories.find(accessory => accessory.UUID === waterBody.waterBodyId);
+          if (existingAccessory) {
+            this.log.info('Restoring existing accessory from cache:', existingAccessory.displayName);
+
+            existingAccessory.context.device = waterBody;
+            this.api.updatePlatformAccessories([existingAccessory]);
+            new WaterguruPlatformAccessory(this, existingAccessory);
+          } else {
+            // the accessory does not yet exist, so we need to create it
+            this.log.info('Adding new accessory:', waterBody.name);
+            const accessory = new this.api.platformAccessory(waterBody.name, waterBody.waterBodyId);
+            accessory.context.device = waterBody;
+            new WaterguruPlatformAccessory(this, accessory);
+
+            this.api.registerPlatformAccessories(PLUGIN_NAME, PLATFORM_NAME, [accessory]);
+          }
+        }
+      }));
+  }
 }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -3,51 +3,57 @@ import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 import { WaterguruPlatform } from './platform';
 
 export class WaterguruPlatformAccessory {
-  private temperatureService: Service;
-  private phService: Service;
-  private chlorineService: Service;
+  private service!: Service;
 
   constructor(
     private readonly platform: WaterguruPlatform,
     private readonly accessory: PlatformAccessory,
   ) {
+    const key = this.accessory.context.measurementKey;
 
-    // Set accessory information
+    // Accessory information
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, 'WaterGuru')
-      .setCharacteristic(this.platform.Characteristic.Model, 'Unknown')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, 'Unknown');
+      .setCharacteristic(this.platform.Characteristic.Model, 'Sense')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.accessory.UUID);
 
-    // Temperature Service (standard HomeKit — works as-is)
-    this.temperatureService = this.accessory.getService(this.platform.Service.TemperatureSensor) ||
-      this.accessory.addService(this.platform.Service.TemperatureSensor);
-    this.temperatureService.setCharacteristic(this.platform.Characteristic.Name, 'Temperature');
-    this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
-      .onGet(this.getCurrentTemp.bind(this));
+    if (key === 'temp') {
+      this.service = this.accessory.getService(this.platform.Service.TemperatureSensor) ||
+        this.accessory.addService(this.platform.Service.TemperatureSensor);
+      this.service.setCharacteristic(this.platform.Characteristic.Name, 'Pool Temperature');
+      this.service.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
+        .onGet(this.getCurrentTemp.bind(this));
+    } else if (key === 'ph') {
+      this.service = this.accessory.getService(this.platform.Service.LightSensor) ||
+        this.accessory.addService(this.platform.Service.LightSensor);
+      this.service.setCharacteristic(this.platform.Characteristic.Name, 'Pool pH');
+      this.service.getCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel)
+        .setProps({ minValue: 0, maxValue: 14, minStep: 0.1 })
+        .onGet(this.getCurrentPh.bind(this));
+    } else if (key === 'chlorine') {
+      this.service = this.accessory.getService(this.platform.Service.LightSensor) ||
+        this.accessory.addService(this.platform.Service.LightSensor);
+      this.service.setCharacteristic(this.platform.Characteristic.Name, 'Pool Chlorine');
+      this.service.getCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel)
+        .setProps({ minValue: 0, maxValue: 10, minStep: 0.1 })
+        .onGet(this.getCurrentFreeChlorine.bind(this));
+    }
+  }
 
-    // pH Service — exposed as TemperatureSensor so HomeKit displays decimals (e.g. 7.5°)
-    this.phService = this.accessory.getService('pH') ||
-      this.accessory.addService(this.platform.Service.TemperatureSensor, 'pH', 'waterguru-ph');
-    this.phService.setCharacteristic(this.platform.Characteristic.Name, 'pH');
-    this.phService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
-      .onGet(this.getCurrentPh.bind(this));
-
-    // Chlorine Service — also exposed as TemperatureSensor so HomeKit displays decimals (e.g. 2.3°)
-    this.chlorineService = this.accessory.getService('Chlorine') ||
-      this.accessory.addService(this.platform.Service.TemperatureSensor, 'Chlorine', 'waterguru-chlorine');
-    this.chlorineService.setCharacteristic(this.platform.Characteristic.Name, 'Chlorine');
-    this.chlorineService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
-      .onGet(this.getCurrentFreeChlorine.bind(this));
+  async getWaterBody() {
+    const waterBodyId = this.accessory.context.device.waterBodyId;
+    const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(waterBodyId);
+    if (!waterBody) {
+      throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
+    }
+    this.accessory.context.device = waterBody;
+    return waterBody;
   }
 
   async getCurrentTemp(): Promise<CharacteristicValue> {
     try {
-      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
-      if (!waterBody) {
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-      }
-      this.accessory.context.device = waterBody;
-      return (5 / 9) * (this.accessory.context.device.waterTemp - 32);
+      const waterBody = await this.getWaterBody();
+      return (5 / 9) * (waterBody.waterTemp - 32);
     } catch (error) {
       this.platform.log.error('Failed to get temperature:', error);
       throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
@@ -56,12 +62,8 @@ export class WaterguruPlatformAccessory {
 
   async getCurrentFreeChlorine(): Promise<CharacteristicValue> {
     try {
-      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
-      if (!waterBody) {
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-      }
-      this.accessory.context.device = waterBody;
-      const measurement = this.accessory.context.device.measurements.find((m) => m.type === 'FREE_CL');
+      const waterBody = await this.getWaterBody();
+      const measurement = waterBody.measurements.find((m) => m.type === 'FREE_CL');
       if (!measurement) {
         throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
       }
@@ -74,12 +76,8 @@ export class WaterguruPlatformAccessory {
 
   async getCurrentPh(): Promise<CharacteristicValue> {
     try {
-      const waterBody = await this.platform.waterguruSvc?.getWaterbodyInfo(this.accessory.UUID);
-      if (!waterBody) {
-        throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
-      }
-      this.accessory.context.device = waterBody;
-      const measurement = this.accessory.context.device.measurements.find((m) => m.type === 'PH');
+      const waterBody = await this.getWaterBody();
+      const measurement = waterBody.measurements.find((m) => m.type === 'PH');
       if (!measurement) {
         throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
       }

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -25,22 +25,18 @@ export class WaterguruPlatformAccessory {
     this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .onGet(this.getCurrentTemp.bind(this));
 
-    // pH Service — exposed as HumiditySensor (native HomeKit type Apple Home will display)
-    // pH 0–14 is scaled to 0–100 for the humidity characteristic (multiply by 100/14 ≈ 7.14)
-    // Example: pH 7.4 → displayed as ~52.9 "humidity" — label the tile "pH" in the Home app
+    // pH Service — exposed as TemperatureSensor so HomeKit displays decimals (e.g. 7.5°)
     this.phService = this.accessory.getService('pH') ||
-      this.accessory.addService(this.platform.Service.HumiditySensor, 'pH', 'waterguru-ph');
+      this.accessory.addService(this.platform.Service.TemperatureSensor, 'pH', 'waterguru-ph');
     this.phService.setCharacteristic(this.platform.Characteristic.Name, 'pH');
-    this.phService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+    this.phService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .onGet(this.getCurrentPh.bind(this));
 
-    // Chlorine Service — also exposed as HumiditySensor with a unique subtype
-    // Free chlorine 0–10 ppm is scaled to 0–100 (multiply by 10)
-    // Example: 2.5 ppm → displayed as 25 "humidity" — label the tile "Chlorine" in the Home app
+    // Chlorine Service — also exposed as TemperatureSensor so HomeKit displays decimals (e.g. 2.3°)
     this.chlorineService = this.accessory.getService('Chlorine') ||
-      this.accessory.addService(this.platform.Service.HumiditySensor, 'Chlorine', 'waterguru-chlorine');
+      this.accessory.addService(this.platform.Service.TemperatureSensor, 'Chlorine', 'waterguru-chlorine');
     this.chlorineService.setCharacteristic(this.platform.Characteristic.Name, 'Chlorine');
-    this.chlorineService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+    this.chlorineService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .onGet(this.getCurrentFreeChlorine.bind(this));
   }
 

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -2,17 +2,6 @@ import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 
 import { WaterguruPlatform } from './platform';
 
-// Fixed UUIDs — must never change or HomeKit will create orphaned services on every restart
-const CustomServiceUUID = {
-  PhService: 'A0000001-079E-48FF-8F27-9C2605A29F52',
-  ChlorineService: 'A0000002-079E-48FF-8F27-9C2605A29F52',
-};
-
-const CustomCharacteristicUUID = {
-  CurrentPh: 'B863F10C-079E-48FF-8F27-9C2605A29F52',
-  CurrentChlorine: 'B863F10D-079E-48FF-8F27-9C2605A29F52',
-};
-
 export class WaterguruPlatformAccessory {
   private temperatureService: Service;
   private phService: Service;
@@ -29,42 +18,30 @@ export class WaterguruPlatformAccessory {
       .setCharacteristic(this.platform.Characteristic.Model, 'Unknown')
       .setCharacteristic(this.platform.Characteristic.SerialNumber, 'Unknown');
 
-    // Create Temperature Service
+    // Temperature Service (standard HomeKit — works as-is)
     this.temperatureService = this.accessory.getService(this.platform.Service.TemperatureSensor) ||
-     this.accessory.addService(this.platform.Service.TemperatureSensor);
+      this.accessory.addService(this.platform.Service.TemperatureSensor);
     this.temperatureService.setCharacteristic(this.platform.Characteristic.Name, 'Temperature');
     this.temperatureService.getCharacteristic(this.platform.Characteristic.CurrentTemperature)
       .onGet(this.getCurrentTemp.bind(this));
 
-    // Create Ph Service
-    this.phService = this.accessory.services.find(service => service.UUID === CustomServiceUUID.PhService) ||
-      this.accessory.addService(new this.platform.Service('Ph', CustomServiceUUID.PhService));
-    this.phService.setCharacteristic(this.platform.Characteristic.Name, 'Ph');
-    const CurrentPh = new this.platform.api.hap.Characteristic('Current Ph', CustomCharacteristicUUID.CurrentPh, {
-      format: this.platform.Characteristic.Formats.FLOAT,
-      unit: 'ph',
-      minValue: 0,
-      maxValue: 14,
-      minStep: 0.1,
-      perms: [this.platform.Characteristic.Perms.PAIRED_READ, this.platform.Characteristic.Perms.NOTIFY],
-    });
-    this.phService.addCharacteristic(CurrentPh);
-    CurrentPh.onGet(this.getCurrentPh.bind(this));
+    // pH Service — exposed as HumiditySensor (native HomeKit type Apple Home will display)
+    // pH 0–14 is scaled to 0–100 for the humidity characteristic (multiply by 100/14 ≈ 7.14)
+    // Example: pH 7.4 → displayed as ~52.9 "humidity" — label the tile "pH" in the Home app
+    this.phService = this.accessory.getService('pH') ||
+      this.accessory.addService(this.platform.Service.HumiditySensor, 'pH', 'waterguru-ph');
+    this.phService.setCharacteristic(this.platform.Characteristic.Name, 'pH');
+    this.phService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+      .onGet(this.getCurrentPh.bind(this));
 
-    // Create Chlorine Service
-    this.chlorineService = this.accessory.services.find(service => service.UUID === CustomServiceUUID.ChlorineService) ||
-      this.accessory.addService(new this.platform.Service('Chlorine', CustomServiceUUID.ChlorineService));
+    // Chlorine Service — also exposed as HumiditySensor with a unique subtype
+    // Free chlorine 0–10 ppm is scaled to 0–100 (multiply by 10)
+    // Example: 2.5 ppm → displayed as 25 "humidity" — label the tile "Chlorine" in the Home app
+    this.chlorineService = this.accessory.getService('Chlorine') ||
+      this.accessory.addService(this.platform.Service.HumiditySensor, 'Chlorine', 'waterguru-chlorine');
     this.chlorineService.setCharacteristic(this.platform.Characteristic.Name, 'Chlorine');
-    const CurrentChlorine = new this.platform.api.hap.Characteristic('Current Chlorine', CustomCharacteristicUUID.CurrentChlorine, {
-      format: this.platform.Characteristic.Formats.FLOAT,
-      unit: 'ppm',
-      minValue: 0,
-      maxValue: 10,
-      minStep: 0.1,
-      perms: [this.platform.Characteristic.Perms.PAIRED_READ, this.platform.Characteristic.Perms.NOTIFY],
-    });
-    this.chlorineService.addCharacteristic(CurrentChlorine);
-    CurrentChlorine.onGet(this.getCurrentFreeChlorine.bind(this));
+    this.chlorineService.getCharacteristic(this.platform.Characteristic.CurrentRelativeHumidity)
+      .onGet(this.getCurrentFreeChlorine.bind(this));
   }
 
   async getCurrentTemp(): Promise<CharacteristicValue> {
@@ -92,7 +69,8 @@ export class WaterguruPlatformAccessory {
       if (!measurement) {
         throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
       }
-      return parseFloat(measurement.value);
+      // Scale 0–10 ppm → 0–100 for HomeKit humidity characteristic
+      return Math.min(100, Math.max(0, parseFloat(measurement.value) * 10));
     } catch (error) {
       this.platform.log.error('Failed to get free chlorine:', error);
       throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
@@ -110,7 +88,8 @@ export class WaterguruPlatformAccessory {
       if (!measurement) {
         throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
       }
-      return parseFloat(measurement.value);
+      // Scale 0–14 pH → 0–100 for HomeKit humidity characteristic
+      return Math.min(100, Math.max(0, parseFloat(measurement.value) * (100 / 14)));
     } catch (error) {
       this.platform.log.error('Failed to get pH:', error);
       throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);

--- a/src/platformAccessory.ts
+++ b/src/platformAccessory.ts
@@ -69,8 +69,7 @@ export class WaterguruPlatformAccessory {
       if (!measurement) {
         throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
       }
-      // Scale 0–10 ppm → 0–100 for HomeKit humidity characteristic
-      return Math.min(100, Math.max(0, parseFloat(measurement.value) * 10));
+      return parseFloat(measurement.value);
     } catch (error) {
       this.platform.log.error('Failed to get free chlorine:', error);
       throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
@@ -88,8 +87,7 @@ export class WaterguruPlatformAccessory {
       if (!measurement) {
         throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);
       }
-      // Scale 0–14 pH → 0–100 for HomeKit humidity characteristic
-      return Math.min(100, Math.max(0, parseFloat(measurement.value) * (100 / 14)));
+      return parseFloat(measurement.value);
     } catch (error) {
       this.platform.log.error('Failed to get pH:', error);
       throw new this.platform.api.hap.HapStatusError(this.platform.api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE);


### PR DESCRIPTION
Utilizing light sensor device types for pH and Chlorine allows HomeKit to display the values as a decimal (displays as lux).  
<img width="1320" height="1216" alt="IMG_6508" src="https://github.com/user-attachments/assets/c2b4c61a-edf8-4ad3-b898-9b5a0f5923b1" />
